### PR TITLE
[Park] 이슈 작성 페이지 - 레이아웃 및 post 요청

### DIFF
--- a/fe/src/components/Container.tsx
+++ b/fe/src/components/Container.tsx
@@ -23,14 +23,22 @@ const Container = styled.div<{
   width?: string;
   height?: string;
   margin?: string;
+  mt?: string;
+  mb?: string;
+  ml?: string;
+  mr?: string;
   padding?: string;
   flexInfo?: FlexTypes;
   gap?: number;
 }>`
-  ${({ width, height, margin, padding, gap }) => css`
+  ${({ width, height, margin, mt, mb, ml, mr, padding, gap }) => css`
     width: ${width};
     height: ${height};
     margin: ${margin};
+    ${mt && `margin-top: ${mt}`};
+    ${mb && `margin-bottom: ${mb}`};
+    ${ml && `margin-left: ${ml}`};
+    ${mr && `margin-right: ${mr}`};
     padding: ${padding};
     gap: ${gap}rem;
   `}

--- a/fe/src/components/Container.tsx
+++ b/fe/src/components/Container.tsx
@@ -30,17 +30,42 @@ const Container = styled.div<{
   padding?: string;
   flexInfo?: FlexTypes;
   gap?: number;
+  position?: string;
+  left?: string;
+  right?: string;
+  top?: string;
+  bottom?: string;
 }>`
-  ${({ width, height, margin, mt, mb, ml, mr, padding, gap }) => css`
-    width: ${width};
-    height: ${height};
-    margin: ${margin};
-    ${mt && `margin-top: ${mt}`};
-    ${mb && `margin-bottom: ${mb}`};
-    ${ml && `margin-left: ${ml}`};
-    ${mr && `margin-right: ${mr}`};
-    padding: ${padding};
-    gap: ${gap}rem;
+  ${({
+    width,
+    height,
+    margin,
+    mt,
+    mb,
+    ml,
+    mr,
+    padding,
+    gap,
+    position,
+    left,
+    right,
+    top,
+    bottom,
+  }) => css`
+    ${width && `width: ${width};`}
+    ${height && `height: ${height};`}
+    ${margin && `margin: ${margin};`}
+    ${mt && `margin-top: ${mt};`}
+    ${mb && `margin-bottom: ${mb};`}
+    ${ml && `margin-left: ${ml};`}
+    ${mr && `margin-right: ${mr};`}
+    ${padding && `padding: ${padding};`}
+    ${gap && `gap : ${gap}rem;`}
+    ${position && `position : ${position};`}
+    ${left && `left : ${left};`}
+    ${right && `right : ${right};`}
+    ${top && `top : ${top};`}
+    ${bottom && `bottom : ${bottom};`}
   `}
 
   ${({ flexInfo }) => flexInfo && mixin.flexMixin(flexInfo)}

--- a/fe/src/components/Divider.tsx
+++ b/fe/src/components/Divider.tsx
@@ -5,8 +5,9 @@ const Divider = styled.div<{
   isVertical?: boolean;
   color?: string;
   margin?: string;
+  opacity?: number;
 }>`
-  opacity: 0.3;
+  opacity: ${({ opacity }) => opacity || 0.3};
   ${({
     isVertical = false,
     color = 'grey',

--- a/fe/src/components/Divider.tsx
+++ b/fe/src/components/Divider.tsx
@@ -4,19 +4,25 @@ const Divider = styled.div<{
   length?: string;
   isVertical?: boolean;
   color?: string;
+  margin?: string;
 }>`
   opacity: 0.3;
-  ${({ isVertical = false, color = 'grey', length = '20px' }) =>
+  ${({
+    isVertical = false,
+    color = 'grey',
+    length = '20px',
+    margin = '0.7rem',
+  }) =>
     isVertical
       ? css`
           height: ${length};
           border-left: 1px solid ${color};
-          margin: 0 0.7rem;
+          margin: 0 ${margin};
         `
       : css`
           width: ${length};
           border-bottom: 1px solid ${color};
-          margin: 0.7rem 0;
+          margin: ${margin} 0;
         `}
 `;
 

--- a/fe/src/components/Divider.tsx
+++ b/fe/src/components/Divider.tsx
@@ -1,0 +1,23 @@
+import styled, { css } from 'styled-components';
+
+const Divider = styled.div<{
+  length?: string;
+  isVertical?: boolean;
+  color?: string;
+}>`
+  opacity: 0.3;
+  ${({ isVertical = false, color = 'grey', length = '20px' }) =>
+    isVertical
+      ? css`
+          height: ${length};
+          border-left: 1px solid ${color};
+          margin: 0 0.7rem;
+        `
+      : css`
+          width: ${length};
+          border-bottom: 1px solid ${color};
+          margin: 0.7rem 0;
+        `}
+`;
+
+export default Divider;

--- a/fe/src/components/SideMenuItem.tsx
+++ b/fe/src/components/SideMenuItem.tsx
@@ -9,7 +9,7 @@ export default function SideMenuItem({
 }): React.ReactElement<{ type: string }> {
   return (
     <Container
-      flexInfo={{ direction: 'row', align: 'center', justify: 'space-between' }}
+      flexInfo={{ align: 'center', justify: 'space-between' }}
       padding="3rem 2rem"
     >
       <TypeTitle>{type}</TypeTitle>

--- a/fe/src/components/SideMenuItem.tsx
+++ b/fe/src/components/SideMenuItem.tsx
@@ -1,0 +1,21 @@
+import AddIcon from '@mui/icons-material/Add';
+import React from 'react';
+import styled from 'styled-components';
+
+import Container from '@components/Container';
+
+export default function SideMenuItem({
+  type,
+}): React.ReactElement<{ type: string }> {
+  return (
+    <Container
+      flexInfo={{ direction: 'row', align: 'center', justify: 'space-between' }}
+      padding="3rem 2rem"
+    >
+      <TypeTitle>{type}</TypeTitle>
+      <AddIcon />
+    </Container>
+  );
+}
+
+const TypeTitle = styled.h6``;

--- a/fe/src/components/Squircle.tsx
+++ b/fe/src/components/Squircle.tsx
@@ -4,8 +4,9 @@ import { widths, heights } from '@constants/lengths';
 import { ITheme } from '@style/theme';
 
 interface ISquircleProps {
-  width?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
+  unit?: string;
   opacity?: number;
   backgroundColor?: string;
   borderLineColor?: string;
@@ -14,11 +15,16 @@ interface ISquircleProps {
 
 const Squircle = styled.div<ISquircleProps>`
   border-radius: 1.2rem;
-  width: ${({ width }) => (width ? `${width}rem` : widths.squircle.default)};
-  height: ${({ height }) =>
-    height ? `${height}rem` : heights.squircle.default};
+  width: ${({ width, unit }) =>
+    typeof width === 'number'
+      ? `${width}${unit || 'rem'}`
+      : width || widths.squircle.default};
+  height: ${({ height, unit }) =>
+    typeof height === 'number'
+      ? `${height}${unit || 'rem'}`
+      : height || heights.squircle.default};
   opacity: ${({ opacity }) => opacity || 1};
-  background-color: ${({ backgroundColor }) =>
+  ${({ backgroundColor }) =>
     backgroundColor && `background-color: ${backgroundColor}`};
   ${({ borderLineColor }) =>
     borderLineColor && `border: 1px solid ${borderLineColor}`}

--- a/fe/src/components/Squircle.tsx
+++ b/fe/src/components/Squircle.tsx
@@ -18,8 +18,8 @@ const Squircle = styled.div<ISquircleProps>`
   height: ${({ height }) =>
     height ? `${height}rem` : heights.squircle.default};
   opacity: ${({ opacity }) => opacity || 1};
-  background-color: ${({ backgroundColor, theme }) =>
-    backgroundColor || theme.palette.default};
+  background-color: ${({ backgroundColor }) =>
+    backgroundColor && `background-color: ${backgroundColor}`};
   ${({ borderLineColor }) =>
     borderLineColor && `border: 1px solid ${borderLineColor}`}
 `;

--- a/fe/src/components/TitleBar.tsx
+++ b/fe/src/components/TitleBar.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+import Container from '@components/Container';
+import Divider from '@components/Divider';
+import { fontSize } from '@constants/fonts';
+
+const Title = styled.h1`
+  font-size: ${fontSize.large};
+`;
+
+export default function TitleBar({ title }) {
+  return (
+    <Container mt="3rem">
+      <Title>{title}</Title>
+      <Divider length="100%" />
+    </Container>
+  );
+}

--- a/fe/src/components/TitleBar.tsx
+++ b/fe/src/components/TitleBar.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import Container from '@components/Container';
-import Divider from '@components/Divider';
 import { fontSize } from '@constants/fonts';
 
 const Title = styled.h1`
@@ -12,7 +11,6 @@ export default function TitleBar({ title }) {
   return (
     <Container mt="3rem">
       <Title>{title}</Title>
-      <Divider length="100%" />
     </Container>
   );
 }

--- a/fe/src/constants/colors.ts
+++ b/fe/src/constants/colors.ts
@@ -14,6 +14,7 @@ const colors = {
   placeholder: '#A0A3BD',
   label: '#6E7191',
   blue: '#007AFF',
+  red: '#d63031',
 };
 
 export default colors;

--- a/fe/src/contexts/HeaderProvider.tsx
+++ b/fe/src/contexts/HeaderProvider.tsx
@@ -24,7 +24,7 @@ const initHeaderState: IHeaderState = {
 */
 const initHeaderStateForDefaultPage: IHeaderState = {
   isLogin: true,
-  isDark: Boolean(localStorage.getItem('isDark')) || false,
+  isDark: JSON.parse(localStorage.getItem('isDark') || 'false'),
   profileUrl: 'https://avatars.githubusercontent.com/u/95538993?v=4',
 };
 //

--- a/fe/src/pages/CreateIssuePage.tsx
+++ b/fe/src/pages/CreateIssuePage.tsx
@@ -1,20 +1,117 @@
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
+import Container from '@components/Container';
+import Divider from '@components/Divider';
 import Header from '@components/Header';
+import SideMenuItem from '@components/SideMenuItem';
+import Squircle from '@components/Squircle';
 import TitleBar from '@components/TitleBar';
-
-const Body = styled.div`
-  max-width: 1440px;
-  margin: 0 auto;
-`;
+import UserIcon from '@components/UserIcon';
+import colors from '@constants/colors';
+import { fontSize } from '@constants/fonts';
 
 export default function CreateIssuePage() {
+  const theme = useTheme();
+
   return (
     <>
       <Header />
       <Body>
         <TitleBar title="새로운 이슈 작성" />
+        <Divider length="100%" margin="2rem" />
+        <GridContainer>
+          <UserIcon size="BIG" />
+          <Container flexInfo={{ direction: 'column' }} gap={1}>
+            <Squircle
+              backgroundColor={theme.palette.darkerBgColor}
+              width={100}
+              unit="%"
+            >
+              <InputBox name="title" placeholder="제목" />
+            </Squircle>
+            <Squircle
+              backgroundColor={theme.palette.darkerBgColor}
+              width={100}
+              height="30rem"
+              unit="%"
+            >
+              <TextAreaBox placeholder="본문" />
+            </Squircle>
+          </Container>
+          <Squircle
+            borderLineColor={theme.palette.borderColor}
+            height="fit-content"
+          >
+            <SideMenuItem type="담당자" />
+            <Divider length="100%" margin="" />
+            <SideMenuItem type="레이블" />
+            <Divider length="100%" margin="" />
+            <SideMenuItem type="마일스톤" />
+          </Squircle>
+        </GridContainer>
+        <Divider length="100%" margin="2rem" />
+        <Container
+          flexInfo={{ direction: 'row' }}
+          position="absolute"
+          right="0"
+          gap={1}
+        >
+          <Squircle>
+            <CancleButton type="button">작성 취소</CancleButton>
+          </Squircle>
+          <Squircle>
+            <SubmitButton type="submit">완료</SubmitButton>
+          </Squircle>
+        </Container>
       </Body>
     </>
   );
 }
+
+const GridContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 15fr 5fr;
+  grid-gap: 1rem;
+`;
+
+const Body = styled.form`
+  position: relative;
+  max-width: 1440px;
+  margin: 0 auto;
+`;
+
+const InputBox = styled.input`
+  width: 100%;
+  height: 100%;
+  color: ${({ theme }) => theme.palette.fontColor};
+  background-color: ${({ theme }) => theme.palette.darkerBgColor};
+  padding: 0rem 1rem;
+`;
+
+const TextAreaBox = styled.textarea`
+  width: 100%;
+  height: 100%;
+  resize: none;
+  padding: 1rem;
+  padding-top: 1.5rem;
+`;
+
+const Button = styled.button`
+  color: ${colors.offWhite};
+  font-size: ${fontSize.medium};
+  width: 100%;
+  height: 100%;
+
+  opacity: 0.5;
+  transition: opacity 0.2s;
+  :hover {
+    opacity: 1;
+  }
+`;
+
+const SubmitButton = styled(Button)`
+  background-color: ${({ theme }) => theme.palette.primary};
+`;
+const CancleButton = styled(Button)`
+  background-color: ${({ theme }) => theme.palette.warning};
+`;

--- a/fe/src/pages/CreateIssuePage.tsx
+++ b/fe/src/pages/CreateIssuePage.tsx
@@ -1,3 +1,6 @@
+import axios from 'axios';
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 
 import Container from '@components/Container';
@@ -10,13 +13,35 @@ import UserIcon from '@components/UserIcon';
 import colors from '@constants/colors';
 import { fontSize } from '@constants/fonts';
 
+interface IFormEventTarget extends EventTarget {
+  subject?: HTMLInputElement;
+  description?: HTMLTextAreaElement;
+}
+
 export default function CreateIssuePage() {
   const theme = useTheme();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const formData: IFormEventTarget = e.target;
+    const subject = formData.subject?.value;
+    const description = formData.description?.value;
+    await axios.post('/api/createIssue', {
+      subject,
+      description,
+    });
+    navigate('/');
+  };
+
+  const handleClickCancleButton = () => {
+    navigate('/');
+  };
 
   return (
     <>
       <Header />
-      <Body>
+      <Body onSubmit={handleSubmit}>
         <TitleBar title="새로운 이슈 작성" />
         <Divider length="100%" margin="2rem" />
         <GridContainer>
@@ -27,7 +52,7 @@ export default function CreateIssuePage() {
               width={100}
               unit="%"
             >
-              <InputBox name="title" placeholder="제목" />
+              <InputBox name="subject" placeholder="제목" />
             </Squircle>
             <Squircle
               backgroundColor={theme.palette.darkerBgColor}
@@ -35,7 +60,7 @@ export default function CreateIssuePage() {
               height="30rem"
               unit="%"
             >
-              <TextAreaBox placeholder="본문" />
+              <TextAreaBox name="description" placeholder="본문" />
             </Squircle>
           </Container>
           <Squircle
@@ -57,7 +82,9 @@ export default function CreateIssuePage() {
           gap={1}
         >
           <Squircle>
-            <CancleButton type="button">작성 취소</CancleButton>
+            <CancleButton type="button" onClick={handleClickCancleButton}>
+              작성 취소
+            </CancleButton>
           </Squircle>
           <Squircle>
             <SubmitButton type="submit">완료</SubmitButton>

--- a/fe/src/pages/CreateIssuePage.tsx
+++ b/fe/src/pages/CreateIssuePage.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 
 import Header from '@components/Header';
-import IssueTable from '@components/IssueTable';
-import UtilBar from '@components/UtilBar';
+import TitleBar from '@components/TitleBar';
 
 const Body = styled.div`
   max-width: 1440px;
@@ -14,8 +13,7 @@ export default function CreateIssuePage() {
     <>
       <Header />
       <Body>
-        <UtilBar />
-        <IssueTable />
+        <TitleBar title="새로운 이슈 작성" />
       </Body>
     </>
   );

--- a/fe/src/pages/JoinPage.tsx
+++ b/fe/src/pages/JoinPage.tsx
@@ -68,6 +68,7 @@ const Wrapper = styled.form`
 const InputBox = styled.input`
   width: 100%;
   height: 100%;
+  color: ${({ theme }) => theme.palette.fontColor};
   background-color: ${({ theme }) => theme.palette.darkerBgColor};
   padding: 0rem 1rem;
 `;

--- a/fe/src/pages/Layout.tsx
+++ b/fe/src/pages/Layout.tsx
@@ -3,6 +3,7 @@ import WbSunnyIcon from '@mui/icons-material/WbSunny';
 import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 
+import Container from '@components/Container';
 import { useHeaderDispatch, useHeaderState } from '@contexts/HeaderProvider';
 
 const ThemeToggleButton = styled.button`
@@ -32,11 +33,11 @@ export default function Layout() {
   };
 
   return (
-    <>
+    <Container padding="0 2rem">
       <Outlet />
       <ThemeToggleButton onClick={handleClickToggleButton}>
         {isDark ? <WbSunnyIcon /> : <NightlightIcon />}
       </ThemeToggleButton>
-    </>
+    </Container>
   );
 }

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -78,7 +78,7 @@ const getLoginButtonBg = (theme, loginType) => {
   switch (loginType) {
     case 'github':
       return css`
-        background-color: ${colors.titleActive};
+        background-color: ${colors.black2};
       `;
     default:
       return css`
@@ -90,7 +90,8 @@ const getLoginButtonBg = (theme, loginType) => {
 const InputBox = styled.input`
   width: 100%;
   height: 100%;
-  background-color: ${colors.inputBg};
+  color: ${({ theme }) => theme.palette.fontColor};
+  background-color: ${({ theme }) => theme.palette.darkerBgColor};
   padding: 0rem 1rem;
 `;
 

--- a/fe/src/server/handlers.ts
+++ b/fe/src/server/handlers.ts
@@ -12,6 +12,7 @@ interface IUser {
 
 let lastUserId = 1;
 const fakeUsers: IUser[] = [];
+const fakeIssues = [...issues];
 
 const postJoin: Parameters<typeof rest.get>[1] = async (req, res, ctx) => {
   const { email, name, password } = req.body;
@@ -46,12 +47,42 @@ const postLogin: Parameters<typeof rest.get>[1] = async (req, res, ctx) => {
 };
 
 const getIssues: Parameters<typeof rest.get>[1] = (_, res, ctx) =>
-  res(ctx.status(200), ctx.json(issues));
+  res(ctx.status(200), ctx.json(fakeIssues));
 
+const postCreateIssue: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
+  const { subject, description } = req.body;
+  const newIssueId = fakeIssues[fakeIssues.length - 1].id + 1;
+  const newIssueNumber = fakeIssues[fakeIssues.length - 1].number + 1;
+  const newIssue = {
+    id: newIssueId,
+    number: newIssueNumber,
+    subject,
+    description,
+    writer: 'happyGyu',
+    profileUrl: 'https://avatars.githubusercontent.com/u/95538993?v=4',
+    status: 'open',
+    createdDatetime: new Date().toISOString(),
+    labels: [
+      {
+        id: 124123,
+        name: '임시라벨',
+      },
+    ],
+    milestones: [
+      {
+        id: 123214,
+        name: '임시마일',
+      },
+    ],
+  };
+  fakeIssues.push(newIssue);
+  return res(ctx.status(201));
+};
 export default function handlers() {
   return [
     rest.post('/api/join', postJoin),
     rest.post('/api/login', postLogin),
     rest.get('/api/issues', getIssues),
+    rest.post('/api/createIssue', postCreateIssue),
   ];
 }

--- a/fe/src/style/GlobalStyle.ts
+++ b/fe/src/style/GlobalStyle.ts
@@ -23,6 +23,19 @@ const GlobalStyle = createGlobalStyle`
       outline:none;
     }
   }
+  textarea{
+    margin:0;
+    padding:0;
+    border:none;
+    height:auto;
+    max-width:100%;
+    background-color:inherit;
+    border-radius:inherit;
+    color:inherit;
+    :focus-visible{
+      outline:none;
+    }
+  }
   a{
     text-decoration:none;
   }

--- a/fe/src/style/theme.ts
+++ b/fe/src/style/theme.ts
@@ -5,6 +5,7 @@ import colors from '@constants/colors';
 export interface IPalette {
   default: string;
   primary: string;
+  warning: string;
   bgColor: string;
   fontColor: string;
   borderColor: string;
@@ -21,6 +22,7 @@ export interface ITheme extends DefaultTheme {
 const darkPalette: IPalette = {
   default: colors.offWhite,
   primary: colors.blue,
+  warning: colors.red,
   bgColor: colors.black,
   fontColor: colors.white1,
   borderColor: colors.grey2,
@@ -33,6 +35,7 @@ const darkPalette: IPalette = {
 const lightPalette: IPalette = {
   default: colors.offWhite,
   primary: colors.blue,
+  warning: colors.red,
   bgColor: colors.white1,
   fontColor: colors.black,
   borderColor: colors.grey1,


### PR DESCRIPTION
issue #13 
close #22 

첫 페이지에 대한 레이아웃 작성 및 제목, 본문만을 포함한 POST 요청을 완료하도록 mock request 를 설정하였습니다
데이터를 보내다보니 HeaderProvider 에서 profileURL 은 사용하고 있는데 사용자에 대한 정보를 다 넣어도 되나? 라는 생각이 들더라구요
그래서 useMe 같은 커스텀 hook 을 만들어서 유저에 대한 정보를 얻을 수 있게 해보는 것도 좋겠다는 생각을 했습니다

+)
본문 Layout 에 padding 좌우 값도 추가로 넣었어요
Page 에 쓰이는 컴포넌트를 별도로 분리하질 않아서 해당 작업을 진행해보지 않을까 싶습니다