### PR TITLE
[Park] IssueDetail 진입 시 Sidemenu Update 되던 것 수정 + progress bar 계산

### DIFF
--- a/fe/src/contexts/HeaderProvider.tsx
+++ b/fe/src/contexts/HeaderProvider.tsx
@@ -69,7 +69,7 @@ function reducer(state: IHeaderState, action: Action): IHeaderState {
 
 export function HeaderProvider({ children }: { children: React.ReactNode }) {
   // TODO: init state 작업에 따라 바꿔서 사용하세요
-  const [state, dispatch] = useReducer(reducer, initHeaderStateForDefaultPage);
+  const [state, dispatch] = useReducer(reducer, initHeaderState);
 
   return (
     <HeaderStateContext.Provider value={state}>

--- a/fe/src/contexts/HeaderProvider.tsx
+++ b/fe/src/contexts/HeaderProvider.tsx
@@ -69,7 +69,7 @@ function reducer(state: IHeaderState, action: Action): IHeaderState {
 
 export function HeaderProvider({ children }: { children: React.ReactNode }) {
   // TODO: init state 작업에 따라 바꿔서 사용하세요
-  const [state, dispatch] = useReducer(reducer, initHeaderState);
+  const [state, dispatch] = useReducer(reducer, initHeaderStateForDefaultPage);
 
   return (
     <HeaderStateContext.Provider value={state}>

--- a/fe/src/pages/CreateIssuePage/index.tsx
+++ b/fe/src/pages/CreateIssuePage/index.tsx
@@ -53,6 +53,10 @@ export default function CreateIssuePage() {
     }
   };
 
+  const handleClickItemAddBtn = (menu) => {
+    menuDispatch({ type: menu.type, data: menu });
+  };
+
   return (
     <Body onSubmit={handleSubmit}>
       <TitleBar title="새로운 이슈 작성" />
@@ -66,7 +70,7 @@ export default function CreateIssuePage() {
           />
           <TextAreaBox />
         </Container>
-        <SideMenu menuState={menuState} menuDispatch={menuDispatch} />
+        <SideMenu menuState={menuState} onClickAddBtn={handleClickItemAddBtn} />
       </GridContainer>
       <Divider margin="2rem" />
       <Container

--- a/fe/src/pages/DefaultPage/IssueTable/IssueTableHeader/index.tsx
+++ b/fe/src/pages/DefaultPage/IssueTable/IssueTableHeader/index.tsx
@@ -102,7 +102,7 @@ export default function IssueTableHeader({
   };
 
   const handleClickStatusChangeItem = async ({ targetStatus }) => {
-    await axios.patch('/api/issues/status/update', {
+    await axios.patch('/api/issues/status', {
       updatedStatus: targetStatus,
       idOfIssues: checkedIssueIds,
     });

--- a/fe/src/pages/IssueDetailPage/IssueBody/ReplySection/ReplyWritingArea/index.tsx
+++ b/fe/src/pages/IssueDetailPage/IssueBody/ReplySection/ReplyWritingArea/index.tsx
@@ -42,7 +42,7 @@ export default function ReplyWritingArea({
         comment: formData.description.value,
       });
     } else if (type === 'EDIT') {
-      await axios.patch(`/api/issues/replies/${originalData?.id}/update`, {
+      await axios.patch(`/api/issues/replies/${originalData?.id}`, {
         comment: formData.description.value,
       });
       if (!finishEdit) throw new Error('Cannot handle finishing edit');

--- a/fe/src/pages/IssueDetailPage/IssueBody/SideMenuSection/index.tsx
+++ b/fe/src/pages/IssueDetailPage/IssueBody/SideMenuSection/index.tsx
@@ -1,6 +1,5 @@
 import DeleteForeverOutlinedIcon from '@mui/icons-material/DeleteForeverOutlined';
 import axios from 'axios';
-import { useEffect, useReducer } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 
@@ -9,58 +8,46 @@ import Container from '@components/layout/Container';
 import AlertDialog from '@components/util/AlertDialog';
 import { useIssueContext } from '@contexts/IssueProvider';
 import SideMenu from '@pages/common/organisms/SideMenu';
-import sideMenuReducer from '@pages/common/organisms/SideMenu/sideMenuReducer';
+
+enum MenuTypeEnum {
+  ASSIGNEE = 'assignees',
+  LABEL = 'labels',
+  MILESTONE = 'milestone',
+}
+
+enum MenuKey {
+  assignees = 'assignees',
+  labels = 'labels',
+  milestone = 'milestoneId',
+}
 
 export default function SideMenuSection() {
   const theme = useTheme();
   const navigate = useNavigate();
-  const { issue: { id, assignees = [], labels = [], milestone } = {} } =
-    useIssueContext();
-  const initState = { assignees, labels, milestone };
-  const [menuState, menuDispatch] = useReducer(sideMenuReducer, initState);
+  const {
+    issue: { id, assignees = [], labels = [], milestone } = {},
+    refetch: issueAxiosRefetch,
+  } = useIssueContext();
+  const menuState = { assignees, labels, milestone };
 
   const handleClickDeleteButton = () => {
     axios.delete(`/api/issues/${id}`);
     navigate('/');
   };
 
-  useEffect(() => {
-    menuDispatch({ type: 'ALL', data: { milestone, assignees, labels } });
-  }, [id]);
-
-  useEffect(() => {
-    const newAssigneeIds = menuState.assignees.map((assignee) => assignee.id);
-    if (!id) return;
-    (async () => {
-      await axios.patch(`/api/issues/${id}/assignees/update`, {
-        assignees: newAssigneeIds,
-      });
-    })();
-  }, [menuState.assignees]);
-
-  useEffect(() => {
-    const newLabelIds = menuState.labels.map((label) => label.id);
-    if (!id) return;
-    (async () => {
-      await axios.patch(`/api/issues/${id}/labels/update`, {
-        labels: newLabelIds,
-      });
-    })();
-  }, [menuState.labels]);
-
-  useEffect(() => {
-    const newMileStoneId = menuState.milestone?.id;
-    if (!id) return;
-    (async () => {
-      await axios.patch(`/api/issues/${id}/milestone/update`, {
-        milestoneId: newMileStoneId,
-      });
-    })();
-  }, [menuState.milestone]);
+  const handleClickSideMenu = async (menu) => {
+    const menuType = MenuTypeEnum[menu.type];
+    const requestBody = {};
+    const requestKey = MenuKey[menuType];
+    const requestValue = getMenuValue(menuType, menuState, menu);
+    requestBody[requestKey] = requestValue;
+    await axios.patch(`/api/issues/${id}/${menuType}`, requestBody);
+    issueAxiosRefetch();
+  };
 
   return (
     <Container flexInfo={{ direction: 'column', align: 'flex-end' }} gap={0.75}>
-      <SideMenu menuState={menuState} menuDispatch={menuDispatch} />
+      <SideMenu menuState={menuState} onClickAddBtn={handleClickSideMenu} />
       <Container mr="2rem">
         <AlertDialog
           sx={{
@@ -79,3 +66,24 @@ export default function SideMenuSection() {
     </Container>
   );
 }
+
+const getMenuValue = (menuType, menuState, menu) => {
+  switch (menuType) {
+    case 'assignees':
+    case 'labels': {
+      const newIds = menuState[menuType].map((type) => type.id);
+      if (newIds.includes(menu.id)) {
+        return newIds.filter((id) => id !== menu.id);
+      }
+      return [...newIds, menu.id];
+    }
+    case 'milestone': {
+      if (menuState.milestone?.id === menu.id) {
+        return null;
+      }
+      return menu.id;
+    }
+    default:
+      throw Error('Unexpected Menu Type on useSideMenuPatch');
+  }
+};

--- a/fe/src/pages/IssueDetailPage/IssueHeader/IssueUtilButtons.tsx
+++ b/fe/src/pages/IssueDetailPage/IssueHeader/IssueUtilButtons.tsx
@@ -28,7 +28,7 @@ export default function IssueUtilButtons({
   const handleClickFinshEditButton = async () => {
     const newTitle = titleRef.current?.value;
     if (!newTitle || newTitle.length === 0) return;
-    await axios.patch(`/api/issues/${id}/subject/update`, {
+    await axios.patch(`/api/issues/${id}/subject`, {
       subject: newTitle,
     });
     setIsTitleEditing(false);
@@ -36,7 +36,7 @@ export default function IssueUtilButtons({
   };
 
   const handleClickToggleIssuStatusButton = async () => {
-    await axios.patch('/api/issues/status/update', {
+    await axios.patch('/api/issues/status', {
       updatedStatus: status === 'OPEN' ? 'CLOSED' : 'OPEN',
       idOfIssues: [id],
     });

--- a/fe/src/pages/MilestonePage/MilestoneTable/MilestoneTableBody/MilestoneTableCell/ButtonBoxes/index.tsx
+++ b/fe/src/pages/MilestonePage/MilestoneTable/MilestoneTableBody/MilestoneTableCell/ButtonBoxes/index.tsx
@@ -13,7 +13,7 @@ export default function ButtonBoxes({ milestoneId, toggleIsEditing }) {
   const { refetch: milestonesRefetch } = useMilestoneContext();
 
   const handleClickCloseButton = async () => {
-    await axios.patch(`/api/milestones/${milestoneId}/status/update`, {
+    await axios.patch(`/api/milestones/${milestoneId}/status`, {
       updatedStatus: 'CLOSED',
     });
     milestonesRefetch();

--- a/fe/src/pages/common/organisms/SideMenu/Milestone/index.tsx
+++ b/fe/src/pages/common/organisms/SideMenu/Milestone/index.tsx
@@ -1,13 +1,18 @@
 import Container from '@components/layout/Container';
 import ProgressBar from '@pages/common/organisms/SideMenu/Milestone/ProgressBar';
+import { MilestoneType } from '@type/types';
 
-export default function Milestone({ milestone }) {
+export default function Milestone({ milestone }: { milestone: MilestoneType }) {
+  const percent =
+    milestone.totalCountOfIssues === 0
+      ? 0
+      : Math.floor(
+          (milestone.countOfClosedIssues / milestone.totalCountOfIssues) * 100,
+        );
   return (
-    milestone && (
-      <Container flexInfo={{ direction: 'column' }} gap={1}>
-        <ProgressBar percent={40} />
-        <span>{milestone.subject}</span>
-      </Container>
-    )
+    <Container flexInfo={{ direction: 'column' }} gap={1}>
+      <ProgressBar percent={percent} />
+      <span>{milestone.subject}</span>
+    </Container>
   );
 }

--- a/fe/src/pages/common/organisms/SideMenu/SideMenuItem.tsx
+++ b/fe/src/pages/common/organisms/SideMenu/SideMenuItem.tsx
@@ -62,7 +62,7 @@ export default function SideMenuItem({
           <AddIcon sx={{ cursor: 'pointer' }} />
         </PopoverContainer>
       </Container>
-      {getSubBoxByType(type, state)}
+      {state && getSubBoxByType(type, state)}
     </Container>
   );
 }

--- a/fe/src/pages/common/organisms/SideMenu/SideMenuItem.tsx
+++ b/fe/src/pages/common/organisms/SideMenu/SideMenuItem.tsx
@@ -36,17 +36,13 @@ export default function SideMenuItem({
   type,
   state,
   menus,
-  menuDispatch,
+  onClickAddBtn,
 }): React.ReactElement<{
   type: ModalTypes;
   state: MemberType[] | LabelType[] | MilestoneType;
   menuDispatch: MenuDispatchType;
 }> {
   const title = `${KoType[type]} 추가`;
-
-  const handleClickItemAddBtn = (menu) => {
-    menuDispatch({ type, data: menu });
-  };
 
   return (
     <Container padding="2.5rem 2rem">
@@ -61,7 +57,7 @@ export default function SideMenuItem({
           top={2}
           title={title}
           menus={getFormattedMenus(menus, type)}
-          onClickPopoverItem={handleClickItemAddBtn}
+          onClickPopoverItem={onClickAddBtn}
         >
           <AddIcon sx={{ cursor: 'pointer' }} />
         </PopoverContainer>
@@ -78,12 +74,19 @@ function getFormattedMenus(menus, type) {
     case 'ASSIGNEE':
       return menus?.map((menu) => ({
         ...menu,
+        type: 'ASSIGNEE',
         name: menu.identity,
       }));
     case 'MILESTONE':
       return menus?.map((menu) => ({
         ...menu,
+        type: 'MILESTONE',
         name: menu.subject,
+      }));
+    case 'LABEL':
+      return menus?.map((menu) => ({
+        ...menu,
+        type: 'LABEL',
       }));
     default:
       return menus;

--- a/fe/src/pages/common/organisms/SideMenu/index.tsx
+++ b/fe/src/pages/common/organisms/SideMenu/index.tsx
@@ -7,7 +7,7 @@ import { useMemberContext } from '@contexts/MemberProvider';
 import { useMilestoneContext } from '@contexts/MilestoneProvider';
 import SideMenuItem from '@pages/common/organisms/SideMenu/SideMenuItem';
 
-export default function SideMenu({ menuState, menuDispatch }) {
+export default function SideMenu({ menuState, onClickAddBtn }) {
   const theme = useTheme();
   const { members } = useMemberContext();
   const { labels } = useLabelContext();
@@ -19,21 +19,21 @@ export default function SideMenu({ menuState, menuDispatch }) {
         type="ASSIGNEE"
         menus={members}
         state={menuState.assignees}
-        menuDispatch={menuDispatch}
+        onClickAddBtn={onClickAddBtn}
       />
       <Divider margin="" />
       <SideMenuItem
         type="LABEL"
         menus={labels}
         state={menuState.labels}
-        menuDispatch={menuDispatch}
+        onClickAddBtn={onClickAddBtn}
       />
       <Divider margin="" />
       <SideMenuItem
         type="MILESTONE"
         menus={milestones}
         state={menuState.milestone}
-        menuDispatch={menuDispatch}
+        onClickAddBtn={onClickAddBtn}
       />
     </Squircle>
   );

--- a/fe/src/server/dummyData/issues.ts
+++ b/fe/src/server/dummyData/issues.ts
@@ -25,6 +25,10 @@ const issues: IssueType[] = [
       id: 1,
       subject: '이슈 트래커 서비스 구현',
       description: '프론트 및 백엔드 구현',
+      endDate: '2022-07-11',
+      status: 'OPEN',
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 0,
     },
     assignees: [
       {
@@ -69,6 +73,10 @@ const issues: IssueType[] = [
       id: 2,
       subject: '숙소 예약 서비스 구현',
       description: '프론트 및 백엔드 구현',
+      endDate: '2022-07-11',
+      status: 'OPEN',
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 0,
     },
     assignees: [],
     labels: [
@@ -119,6 +127,10 @@ const issues: IssueType[] = [
       id: 3,
       subject: '반찬 주문 서비스 구현',
       description: '프론트 및 백엔드 구현',
+      endDate: '2022-07-11',
+      status: 'OPEN',
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 1,
     },
     assignees: [
       {
@@ -152,9 +164,13 @@ const issues: IssueType[] = [
     profileUrl: alanProfileURL,
     createdDateTime: '2022-06-21T21:23:00',
     milestone: {
-      id: 1,
-      subject: '이슈 트래커 서비스 구현',
-      description: '프론트 및 백엔드 구현',
+      id: 4,
+      subject: '카카오 페이지 구현',
+      description: '프론트 구현',
+      endDate: '2022-06-11',
+      status: 'CLOSED',
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 1,
     },
     assignees: [
       {

--- a/fe/src/server/dummyData/milestones.js
+++ b/fe/src/server/dummyData/milestones.js
@@ -8,8 +8,8 @@ const mileStones = {
       description: '프론트 및 백엔드 구현',
       endDate: '2022-07-11',
       status: 'OPEN',
-      totalCountOfIssues: 10,
-      countOfClosedIssues: 3,
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 0,
     },
     {
       id: 2,
@@ -17,8 +17,8 @@ const mileStones = {
       description: '프론트 및 백엔드 구현',
       endDate: '2022-07-11',
       status: 'OPEN',
-      totalCountOfIssues: 2,
-      countOfClosedIssues: 1,
+      totalCountOfIssues: 1,
+      countOfClosedIssues: 0,
     },
     {
       id: 3,
@@ -27,7 +27,7 @@ const mileStones = {
       endDate: '2022-07-11',
       status: 'OPEN',
       totalCountOfIssues: 1,
-      countOfClosedIssues: 0,
+      countOfClosedIssues: 1,
     },
     {
       id: 4,
@@ -36,7 +36,7 @@ const mileStones = {
       endDate: '2022-06-11',
       status: 'CLOSED',
       totalCountOfIssues: 1,
-      countOfClosedIssues: 0,
+      countOfClosedIssues: 1,
     },
   ],
 };

--- a/fe/src/server/handlers/issueHandlers.ts
+++ b/fe/src/server/handlers/issueHandlers.ts
@@ -34,7 +34,7 @@ const postCreateIssue = (req, res, ctx) => {
       }),
     );
   }
-  const milestone = fakeMileStones.find((m) => m.id === milestoneId);
+  const milestone = fakeMileStones.milestones.find((m) => m.id === milestoneId);
   if (!milestone) {
     return res(
       ctx.status(404),
@@ -138,8 +138,8 @@ const updateLabels: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
 };
 
 const updateMilestone: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
-  const { milestoneId }: { milestoneId: number } = req.body;
-  const milestoneData = fakeMileStones.find(
+  const { milestoneId }: { milestoneId: number | null } = req.body;
+  const milestoneData = fakeMileStones.milestones.find(
     (milestone) => milestone.id === milestoneId,
   );
   const { id: targetId } = req.params;
@@ -231,12 +231,12 @@ export default function issueHandlers() {
     rest.get('/api/issues/:id', getIssue),
     rest.post('/api/issues', postCreateIssue),
     rest.post('/api/issues/:id/replies', addReply),
-    rest.patch('/api/issues/status/update', updateStatus),
-    rest.patch('/api/issues/:id/subject/update', updateSubject),
-    rest.patch('/api/issues/:id/labels/update', updateLabels),
-    rest.patch('/api/issues/:id/milestone/update', updateMilestone),
-    rest.patch('/api/issues/:id/assignees/update', updateAssignees),
-    rest.patch('/api/issues/replies/:id/update', updateReply),
+    rest.patch('/api/issues/status', updateStatus),
+    rest.patch('/api/issues/:id/subject', updateSubject),
+    rest.patch('/api/issues/:id/labels', updateLabels),
+    rest.patch('/api/issues/:id/milestone', updateMilestone),
+    rest.patch('/api/issues/:id/assignees', updateAssignees),
+    rest.patch('/api/issues/replies/:id', updateReply),
     rest.delete('/api/issues/:id', deleteIssue),
   ];
 }

--- a/fe/src/server/handlers/milestoneHandlers.ts
+++ b/fe/src/server/handlers/milestoneHandlers.ts
@@ -147,7 +147,7 @@ export default function milestoneHandlers() {
     rest.get('/api/milestones', getMilestones),
     rest.post('/api/milestones', postMilestones),
     rest.patch('/api/milestones/:id', patchMilestone),
-    rest.patch('/api/milestones/:id/status/update', patchMilestoneState),
+    rest.patch('/api/milestones/:id/status', patchMilestoneState),
     rest.delete('/api/milestones/:id', deleteMilestone),
   ];
 }


### PR DESCRIPTION
closes #72 #73 #74 #75

SideMenuItem Click 시 무조건 menuDispatch 를 사용하는 것을

- CreateIssuePage 에서는 menuDispatch 를 사용할 수 있는 핸들러 작성
- IssueDetailPage 에서는 menuState 를 기반으로 patch 할 수있는 핸들러 작성

하여 해당 핸들러를 호출하도록 변경하였습니다.

이외 익조가 요청하신 /update 문자열 부분을 모두 삭제했습니다.